### PR TITLE
feat: Add game unlock system with prize reveal animations

### DIFF
--- a/InteractiveManga/app/globals.css
+++ b/InteractiveManga/app/globals.css
@@ -318,4 +318,99 @@ body { font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Got
 }
 /* hover効果を削除 */
 
+/* ===== 景品獲得によるコマ画像表示制御 ===== */
+/* ページ4のコマ3とコマ4の画像を初期状態で非表示 */
+[data-page="4"] .koma[data-koma="3"] img.koma-img-el,
+[data-page="4"] .koma[data-koma="4"] img.koma-img-el {
+  opacity: 0;
+  visibility: hidden;
+}
+
+/* 景品獲得後に表示されるクラス */
+[data-page="4"] .koma.prize-unlocked img.koma-img-el {
+  visibility: visible;
+}
+
+[data-page="4"] .koma.prize-unlocked.prize-fresh img.koma-img-el {
+  animation: prizeUnlockFadeIn 1.4s ease-out forwards;
+  transform-origin: center;
+}
+
+[data-page="4"] .koma.prize-unlocked:not(.prize-fresh) img.koma-img-el {
+  opacity: 1;
+}
+
+/* フェードインアニメーション */
+@keyframes prizeUnlockFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ===== テトリススコア制限ツールチップ ===== */
+.nav-area.tetris-locked {
+  cursor: not-allowed;
+}
+
+.tetris-requirement-tooltip {
+  position: absolute;
+  left: 60px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #fffcf9;
+  color: #222;
+  padding: 14px 24px;
+  border-radius: 6px;
+  border: 3px solid #000;
+  font-size: 16px;
+  font-weight: 800;
+  text-align: center;
+  white-space: nowrap;
+  box-shadow:
+    4px 4px 0px rgba(0, 0, 0, 0.3),
+    0 2px 8px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 22;
+  letter-spacing: 0.03em;
+}
+
+/* 吹き出しの三角形 */
+.tetris-requirement-tooltip::before {
+  content: '';
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 10px 12px 10px 0;
+  border-color: transparent #000 transparent transparent;
+}
+
+.tetris-requirement-tooltip::after {
+  content: '';
+  position: absolute;
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 8px 10px 8px 0;
+  border-color: transparent #fffcf9 transparent transparent;
+}
+
+.nav-area.tetris-locked:hover .tetris-requirement-tooltip {
+  opacity: 1;
+  transform: translateY(-50%) translateX(8px);
+}
+
 /* 余白 */

--- a/InteractiveManga/components/MangaBook.tsx
+++ b/InteractiveManga/components/MangaBook.tsx
@@ -13,7 +13,17 @@ const MangaBook: React.FC = () => {
   const [isMiniGameFullScreen, setIsMiniGameFullScreen] = useState(false);
   const [isPageSoundOn, setIsPageSoundOn] = useState(true);
   const cleanupTimerRef = useRef<number | null>(null);
+  const prizeRevealTimerRef = useRef<number | null>(null);
+  const prizeFreshResetTimerRef = useRef<number | null>(null);
   const totalSpreads = 7;
+
+  // UFOキャッチャーの景品獲得状態
+  const [hasUfoPrize, setHasUfoPrize] = useState(false);
+  const [pendingUfoPrize, setPendingUfoPrize] = useState(false);
+  const [isFreshUfoPrize, setIsFreshUfoPrize] = useState(false);
+
+  // テトリスのスコア達成状態
+  const [hasTetrisScore, setHasTetrisScore] = useState(false);
 
   // Zoom animation state
   const cameraRef = useRef<HTMLDivElement>(null);
@@ -41,6 +51,11 @@ const MangaBook: React.FC = () => {
 
   const nextSpread = () => {
     if (isAIBotOpen || isMiniGameOpen || isZoomingIn || isZoomingOut) return;
+    // 見開き5（ページ7）から次に進む場合、テトリススコア300以上が必要
+    if (currentSpread === 5 && !hasTetrisScore) {
+      // スコア未達成の場合は進めない
+      return;
+    }
     if (currentSpread < totalSpreads) showSpread(currentSpread + 1);
   };
 
@@ -94,6 +109,23 @@ const MangaBook: React.FC = () => {
       if (e && (e as any).data && (e as any).data.type === 'CLOSE_MINI_GAME') {
         closeActiveUI();
       }
+      // UFOキャッチャーからの景品獲得通知
+      if (e && (e as any).data && (e as any).data.type === 'UFO_PRIZE_COLLECTED') {
+        const count = (e as any).data.count || 0;
+        if (count >= 1 && !hasUfoPrize) {
+          // ズームアウト完了後に表示するためのフラグを立てる
+          setPendingUfoPrize(true);
+        }
+      }
+      // テトリスからのスコア達成通知
+      if (e && (e as any).data && (e as any).data.type === 'TETRIS_SCORE_ACHIEVED') {
+        if (!hasTetrisScore) {
+          setHasTetrisScore(true);
+          try {
+            localStorage.setItem('hasTetrisScore', 'true');
+          } catch (_) {}
+        }
+      }
     };
 
     window.addEventListener('message', handleMessage);
@@ -103,8 +135,16 @@ const MangaBook: React.FC = () => {
       if (cleanupTimerRef.current) {
         window.clearTimeout(cleanupTimerRef.current);
       }
+      if (prizeRevealTimerRef.current) {
+        window.clearTimeout(prizeRevealTimerRef.current);
+        prizeRevealTimerRef.current = null;
+      }
+      if (prizeFreshResetTimerRef.current) {
+        window.clearTimeout(prizeFreshResetTimerRef.current);
+        prizeFreshResetTimerRef.current = null;
+      }
     };
-  }, []);
+  }, [hasUfoPrize, hasTetrisScore]);
 
   // Prepare page-turn audio element
   useEffect(() => {
@@ -130,10 +170,75 @@ const MangaBook: React.FC = () => {
     } catch (_) {}
   }, []);
 
+  // UFOキャッチャーの景品獲得状態を復元
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('hasUfoPrize');
+      if (saved === 'true') setHasUfoPrize(true);
+    } catch (_) {}
+  }, []);
+
+  // テトリスのスコア達成状態を復元
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('hasTetrisScore');
+      if (saved === 'true') setHasTetrisScore(true);
+    } catch (_) {}
+  }, []);
+
   // Persist preference on change
   useEffect(() => {
     try { localStorage.setItem('pageSoundOn', isPageSoundOn ? '1' : '0'); } catch (_) {}
   }, [isPageSoundOn]);
+
+  // ズームアウト完了後に景品獲得状態を反映（一拍置いてから表示）
+  useEffect(() => {
+    if (!isZoomingOut && !isZoomed && pendingUfoPrize && !hasUfoPrize) {
+      if (prizeRevealTimerRef.current) {
+        window.clearTimeout(prizeRevealTimerRef.current);
+      }
+      prizeRevealTimerRef.current = window.setTimeout(() => {
+        prizeRevealTimerRef.current = null;
+        setIsFreshUfoPrize(true);
+        setHasUfoPrize(true);
+        setPendingUfoPrize(false);
+        try {
+          localStorage.setItem('hasUfoPrize', 'true');
+        } catch (_) {}
+
+        if (prizeFreshResetTimerRef.current) {
+          window.clearTimeout(prizeFreshResetTimerRef.current);
+        }
+        prizeFreshResetTimerRef.current = window.setTimeout(() => {
+          setIsFreshUfoPrize(false);
+          prizeFreshResetTimerRef.current = null;
+        }, 1800);
+      }, 600);
+      return () => {
+        if (prizeRevealTimerRef.current) {
+          window.clearTimeout(prizeRevealTimerRef.current);
+          prizeRevealTimerRef.current = null;
+        }
+      };
+    }
+    return () => {
+      if (prizeRevealTimerRef.current) {
+        window.clearTimeout(prizeRevealTimerRef.current);
+        prizeRevealTimerRef.current = null;
+      }
+    };
+  }, [isZoomingOut, isZoomed, pendingUfoPrize, hasUfoPrize]);
+
+  // ページを離れたタイミングで浮かび上がりアニメーションを確実に解除
+  useEffect(() => {
+    if (currentSpread !== 4 && isFreshUfoPrize) {
+      if (prizeFreshResetTimerRef.current) {
+        window.clearTimeout(prizeFreshResetTimerRef.current);
+        prizeFreshResetTimerRef.current = null;
+      }
+      setIsFreshUfoPrize(false);
+    }
+  }, [currentSpread, isFreshUfoPrize]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -212,9 +317,14 @@ const MangaBook: React.FC = () => {
     komaNum: number;
     assetName: string;
     className?: string;
-  }) => (
+  }) => {
+    // ページ4のコマ3とコマ4に景品獲得状態に応じてクラスを追加
+    const isPrizeUnlocked = pageNum === 4 && (komaNum === 3 || komaNum === 4) && hasUfoPrize;
+    const finalClassName = `koma ${className}${isPrizeUnlocked ? ' prize-unlocked' : ''}${isPrizeUnlocked && isFreshUfoPrize ? ' prize-fresh' : ''}`;
+
+    return (
     <div
-      className={`koma ${className}`}
+      className={finalClassName}
       data-koma={komaNum}
       data-asset={assetName}
       onClick={(e) => {
@@ -279,7 +389,8 @@ const MangaBook: React.FC = () => {
         decoding="async"
       />
     </div>
-  );
+    );
+  };
 
   return (
     <>
@@ -403,7 +514,16 @@ const MangaBook: React.FC = () => {
                 <KomaPanel pageNum={7} komaNum={5} assetName="p7_koma5" className="k5 launcher" />
               </div>
             </div>
-            <div className="nav-area next" onClick={nextSpread} />
+            <div
+              className={`nav-area next${currentSpread === 5 && !hasTetrisScore ? ' tetris-locked' : ''}`}
+              onClick={nextSpread}
+            >
+              {currentSpread === 5 && !hasTetrisScore && (
+                <div className="tetris-requirement-tooltip">
+                  Tetris Over 300 point
+                </div>
+              )}
+            </div>
           </div>
           <div className="page right">
             <div className="manga-page layout-p6" data-page="6">

--- a/InteractiveManga/components/MangaBook.tsx
+++ b/InteractiveManga/components/MangaBook.tsx
@@ -112,19 +112,28 @@ const MangaBook: React.FC = () => {
       // UFOキャッチャーからの景品獲得通知
       if (e && (e as any).data && (e as any).data.type === 'UFO_PRIZE_COLLECTED') {
         const count = (e as any).data.count || 0;
-        if (count >= 1 && !hasUfoPrize) {
-          // ズームアウト完了後に表示するためのフラグを立てる
-          setPendingUfoPrize(true);
+        if (count >= 1) {
+          // 現在の状態を確認してから処理
+          setPendingUfoPrize(prevPending => {
+            if (!prevPending) {
+              // ズームアウト完了後に表示するためのフラグを立てる
+              return true;
+            }
+            return prevPending;
+          });
         }
       }
       // テトリスからのスコア達成通知
       if (e && (e as any).data && (e as any).data.type === 'TETRIS_SCORE_ACHIEVED') {
-        if (!hasTetrisScore) {
-          setHasTetrisScore(true);
-          try {
-            localStorage.setItem('hasTetrisScore', 'true');
-          } catch (_) {}
-        }
+        setHasTetrisScore(prevScore => {
+          if (!prevScore) {
+            try {
+              localStorage.setItem('hasTetrisScore', 'true');
+            } catch (_) {}
+            return true;
+          }
+          return prevScore;
+        });
       }
     };
 
@@ -144,7 +153,7 @@ const MangaBook: React.FC = () => {
         prizeFreshResetTimerRef.current = null;
       }
     };
-  }, [hasUfoPrize, hasTetrisScore]);
+  }, []);
 
   // Prepare page-turn audio element
   useEffect(() => {
@@ -214,17 +223,17 @@ const MangaBook: React.FC = () => {
           prizeFreshResetTimerRef.current = null;
         }, 1800);
       }, 600);
-      return () => {
-        if (prizeRevealTimerRef.current) {
-          window.clearTimeout(prizeRevealTimerRef.current);
-          prizeRevealTimerRef.current = null;
-        }
-      };
     }
+    
+    // Single cleanup function that handles both timers
     return () => {
       if (prizeRevealTimerRef.current) {
         window.clearTimeout(prizeRevealTimerRef.current);
         prizeRevealTimerRef.current = null;
+      }
+      if (prizeFreshResetTimerRef.current) {
+        window.clearTimeout(prizeFreshResetTimerRef.current);
+        prizeFreshResetTimerRef.current = null;
       }
     };
   }, [isZoomingOut, isZoomed, pendingUfoPrize, hasUfoPrize]);

--- a/InteractiveManga/public/mini-games/p4_koma5_ufo.html
+++ b/InteractiveManga/public/mini-games/p4_koma5_ufo.html
@@ -454,7 +454,10 @@
 
     function checkGrab(){ const p=crane.position; let closest=null, dist=Infinity; prizes.forEach(pr=>{ const d=Math.hypot(pr.position.x - p.x, pr.position.z - p.z); if(d<.5 && d<dist){ dist=d; closest=pr; } }); if(closest && Math.random() > 0.1){ isHoldingPrize = closest; } }
 
-    function dropPrize(){ if(isHoldingPrize){ new TWEEN.Tween(isHoldingPrize.position).to({ y:-3.5 }, 500).easing(TWEEN.Easing.Bounce.Out).start().onComplete(()=>{ const data={ type:isHoldingPrize.prizeType.type, name:isHoldingPrize.prizeType.name, color:isHoldingPrize.prizeType.color, count:1 }; collectedPrizes.push(data); scene.remove(isHoldingPrize); prizes = prizes.filter(p=>p!==isHoldingPrize); prizeCount++; showPrizeModal(isHoldingPrize.prizeType.name); isHoldingPrize=null; }); }
+    function dropPrize(){ if(isHoldingPrize){ new TWEEN.Tween(isHoldingPrize.position).to({ y:-3.5 }, 500).easing(TWEEN.Easing.Bounce.Out).start().onComplete(()=>{ const data={ type:isHoldingPrize.prizeType.type, name:isHoldingPrize.prizeType.name, color:isHoldingPrize.prizeType.color, count:1 }; collectedPrizes.push(data); scene.remove(isHoldingPrize); prizes = prizes.filter(p=>p!==isHoldingPrize); prizeCount++; showPrizeModal(isHoldingPrize.prizeType.name); isHoldingPrize=null;
+      // 親ウィンドウへ景品獲得を通知
+      try { window.parent.postMessage({ type: 'UFO_PRIZE_COLLECTED', count: collectedPrizes.length }, window.location.origin); } catch(_){}
+      }); }
       new TWEEN.Tween(leftArm.rotation).to({ z:-.5 }, 500).start(); new TWEEN.Tween(rightArm.rotation).to({ z:.5 }, 500).start().onComplete(()=>{ new TWEEN.Tween(crane.position).to({ x:0, z:0 }, 1000).onUpdate(()=>{ if(craneShadow){ craneShadow.position.x = crane.position.x; craneShadow.position.z = crane.position.z; } }).start().onComplete(()=>{ craneState='idle'; }); }); }
 
     function showPrizeModal(name){ document.getElementById('modal').style.display='block'; createFireworks(); }

--- a/InteractiveManga/public/mini-games/p7_koma5_tetris.html
+++ b/InteractiveManga/public/mini-games/p7_koma5_tetris.html
@@ -136,6 +136,7 @@
                 this.currentY = 0;
                 this.dropTime = 0;
                 this.lastTime = 0;
+                this.hasNotifiedScore = false; // スコア300達成通知フラグ
                 
                 // テトロミノの形状
                 this.pieces = [
@@ -273,6 +274,17 @@
                 if (lines > 0) {
                     this.score += lines * 100;
                     document.getElementById('score').textContent = this.score;
+
+                    // スコアが300以上になったら親ウィンドウに通知
+                    if (this.score >= 300 && !this.hasNotifiedScore) {
+                        this.hasNotifiedScore = true;
+                        try {
+                            window.parent.postMessage({
+                                type: 'TETRIS_SCORE_ACHIEVED',
+                                score: this.score
+                            }, window.location.origin);
+                        } catch (e) {}
+                    }
                 }
             }
             
@@ -380,6 +392,7 @@
                 this.score = 0;
                 this.gameOver = false;
                 this.dropTime = 0;
+                this.hasNotifiedScore = false; // 通知フラグをリセット
                 document.getElementById('score').textContent = 0;
                 document.getElementById('gameOver').classList.remove('show');
                 this.spawnPiece();


### PR DESCRIPTION
## 概要
UFOキャッチャーとテトリスのゲーム進行連動機能を実装しました。

## 実装内容

### 1. UFOキャッチャー景品獲得連動
- **機能**: UFOキャッチャーで景品を1個以上獲得すると、ページ4のコマ3・4の画像がフェードイン表示
- **演出**: ズームアウト完了後、0.6秒待機してから1.4秒かけてフェードイン
- **永続化**: localStorage で状態を保存し、リロード後も表示を維持

### 2. テトリススコア制限機能
- **機能**: ページ7（見開き5）から次ページに進むにはテトリスで300点以上が必要
- **UI**: 未達成時、左端ナビゲーションエリアにホバーで「Tetris Over 300 point」ツールチップ表示
- **デザイン**: 漫画風の吹き出しデザイン（黒枠、クリーム色背景、ドロップシャドウ）
- **永続化**: localStorage で達成状態を保存

## 技術的な実装

### postMessage 通信
- ミニゲーム（iframe）から親ウィンドウへ通知
- `UFO_PRIZE_COLLECTED`: 景品獲得時
- `TETRIS_SCORE_ACHIEVED`: スコア300達成時

### CSS アニメーション
```css
@keyframes prizeUnlockFadeIn {
  from { opacity: 0; transform: scale(0.96); }
  to { opacity: 1; transform: scale(1); }
}
```

### 状態管理
- React の useState で状態管理
- localStorage で永続化
- ページ遷移時も状態を保持

## テスト方法

### UFOキャッチャー機能
1. ページ4のUFOキャッチャー（コマ5）をプレイ
2. 景品を1個以上獲得
3. マンガに戻る
4. コマ3・4がフェードイン表示されることを確認

### テトリス制限機能
1. ページ7のテトリスをプレイせずに次ページへ進もうとする
2. 左端にカーソルを当てるとツールチップ表示
3. テトリスで300点達成後は次ページに進めることを確認

## スクリーンショット
（必要に応じて追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)