### PR TITLE
feat: モバイル縦読み(Webtoon)版とAIBot会話ギミックを追加

### DIFF
--- a/InteractiveManga/.claude/launch.json
+++ b/InteractiveManga/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "manga-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/InteractiveManga/app/globals.css
+++ b/InteractiveManga/app/globals.css
@@ -247,6 +247,13 @@ body { font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Got
 .ai-bot-wrapper.active { opacity: 1; visibility: visible; pointer-events: auto; }
 
 .ai-bot-container { width: 100%; height: 100%; position: relative; background-image: url('/images/AIbot.png'); background-size: contain; background-position: center; background-repeat: no-repeat; }
+
+@media (max-width: 768px) {
+  .ai-bot-container {
+    background-size: auto 62%;
+    background-position: center 32%;
+  }
+}
 .image-background { position: absolute; inset: 0; pointer-events: none; }
 .message-counter { position: absolute; top: 20px; left: 20px; background: rgba(255, 255, 255, 0.95); color: #333; padding: 10px 20px; border-radius: 20px; font-size: 18px; font-weight: bold; z-index: 15; border: 2px solid rgba(0, 0, 0, 0.1); box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2); }
 
@@ -265,6 +272,112 @@ body { font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Got
 
 .back-btn { position: fixed; top: 20px; right: 40px; color: white; font-size: 40px; font-weight: bold; cursor: pointer; opacity: 0; z-index: 45; transition: opacity .3s; pointer-events: none; background: rgba(0,0,0,.3); width: 50px; height: 50px; border-radius: 50%; display:flex; align-items:center; justify-content:center; }
 .back-btn.visible { opacity: .85; pointer-events: auto; }
+
+/* ===== ダイアログ式の会話ウィンドウ ===== */
+.ai-dialogue-box {
+  position: absolute;
+  left: 50%;
+  bottom: 5%;
+  transform: translateX(-50%);
+  width: min(800px, 92%);
+  background: linear-gradient(180deg, rgba(20,20,30,.94), rgba(20,20,30,.88));
+  color: #fff;
+  border: 2px solid rgba(255,255,255,.18);
+  border-radius: 14px;
+  padding: 18px 22px 22px;
+  box-shadow: 0 18px 40px rgba(0,0,0,.45);
+  z-index: 12;
+  cursor: pointer;
+  user-select: none;
+  animation: aiDialogueFadeIn .25s ease-out;
+}
+
+@keyframes aiDialogueFadeIn {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.ai-dialogue-speaker {
+  display: inline-block;
+  padding: 4px 12px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: .08em;
+  border-radius: 999px;
+  margin-bottom: 12px;
+}
+
+.ai-dialogue-text {
+  font-size: 19px;
+  line-height: 1.7;
+  font-weight: 500;
+  letter-spacing: .02em;
+  min-height: 3.4em;
+  white-space: pre-wrap;
+}
+
+.ai-dialogue-next {
+  margin-top: 10px;
+  text-align: right;
+  font-size: 13px;
+  color: rgba(255,255,255,.65);
+  animation: aiDialogueBlink 1.6s ease-in-out infinite;
+}
+
+@keyframes aiDialogueBlink {
+  0%, 100% { opacity: .5; }
+  50% { opacity: 1; }
+}
+
+.ai-choice-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  cursor: default;
+  margin-top: 4px;
+}
+
+.ai-choice-prompt {
+  font-size: 14px;
+  color: rgba(255,255,255,.7);
+  margin-bottom: 4px;
+}
+
+.ai-choice-btn {
+  width: 100%;
+  text-align: left;
+  padding: 14px 18px;
+  font-size: 16px;
+  font-weight: 700;
+  color: #fff;
+  background: rgba(255,255,255,.08);
+  border: 2px solid rgba(255,255,255,.22);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background .2s, border-color .2s, transform .12s;
+}
+
+.ai-choice-btn:hover,
+.ai-choice-btn:focus-visible {
+  background: rgba(255,255,255,.16);
+  border-color: rgba(255,255,255,.45);
+  outline: none;
+}
+
+.ai-choice-btn:active {
+  transform: translateY(1px);
+}
+
+@media (max-width: 768px) {
+  .ai-dialogue-box {
+    padding: 14px 16px 18px;
+    bottom: 4%;
+  }
+  .ai-dialogue-text { font-size: 17px; }
+  .ai-choice-btn { font-size: 15px; padding: 12px 14px; }
+}
 /* hover効果を削除 */
 
 /* ===== サウンドトグル ===== */
@@ -326,6 +439,39 @@ body { font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Got
   visibility: hidden;
 }
 
+/* 未獲得時：「？」プレースホルダを表示してギミックを示唆 */
+[data-page="4"] .koma[data-koma="3"]:not(.prize-unlocked),
+[data-page="4"] .koma[data-koma="4"]:not(.prize-unlocked) {
+  background: repeating-linear-gradient(
+    45deg,
+    #f4ede0,
+    #f4ede0 10px,
+    #e8dec9 10px,
+    #e8dec9 20px
+  );
+}
+
+[data-page="4"] .koma[data-koma="3"]:not(.prize-unlocked)::after,
+[data-page="4"] .koma[data-koma="4"]:not(.prize-unlocked)::after {
+  content: '?';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(40px, 12vw, 80px);
+  font-weight: 900;
+  color: rgba(0, 0, 0, .28);
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  animation: prizePlaceholderFloat 2.4s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes prizePlaceholderFloat {
+  0%, 100% { transform: translateY(0); opacity: .55; }
+  50% { transform: translateY(-4px); opacity: 1; }
+}
+
 /* 景品獲得後に表示されるクラス */
 [data-page="4"] .koma.prize-unlocked img.koma-img-el {
   visibility: visible;
@@ -353,7 +499,8 @@ body { font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Got
 }
 
 /* ===== テトリススコア制限ツールチップ ===== */
-.nav-area.tetris-locked {
+.nav-area.tetris-locked,
+.nav-area.aibot-locked {
   cursor: not-allowed;
 }
 
@@ -408,9 +555,179 @@ body { font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', 'Hiragino Kaku Got
   border-color: transparent #fffcf9 transparent transparent;
 }
 
-.nav-area.tetris-locked:hover .tetris-requirement-tooltip {
+.nav-area.tetris-locked:hover .tetris-requirement-tooltip,
+.nav-area.aibot-locked:hover .tetris-requirement-tooltip {
   opacity: 1;
   transform: translateY(-50%) translateX(8px);
+}
+
+/* ===== Webtoon（モバイル縦読み）===== */
+@media (max-width: 768px) {
+  body {
+    display: block;
+    align-items: stretch;
+    justify-content: flex-start;
+    overflow-x: hidden;
+    overflow-y: auto;
+    background: linear-gradient(180deg, #1a1a2e 0%, #16213e 100%);
+  }
+}
+
+.webtoon-camera {
+  width: 100%;
+  min-height: 100vh;
+  display: block;
+  position: relative;
+  transform-origin: var(--zoom-origin-x) var(--zoom-origin-y);
+}
+
+.webtoon-container {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 16px 12px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.webtoon-cover {
+  width: 100%;
+  background: #fff;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, .45);
+}
+
+.webtoon-cover-image {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.webtoon-page {
+  width: 100%;
+  aspect-ratio: 520 / 690;
+  background: #fffcf9;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, .45);
+  position: relative;
+}
+
+.webtoon-page .manga-page {
+  border-radius: 0;
+}
+
+@media (max-width: 768px) {
+  .webtoon-page .manga-page {
+    padding: 12px;
+    border-width: 2px;
+  }
+  .webtoon-page .koma {
+    border-width: 2px;
+  }
+}
+
+.webtoon-locked-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+}
+
+.webtoon-locked-section.is-locked .webtoon-page,
+.webtoon-locked-section.is-locked .webtoon-cover {
+  filter: blur(6px) brightness(.55);
+  pointer-events: none;
+  user-select: none;
+}
+
+.webtoon-lock-gate {
+  position: sticky;
+  top: 28vh;
+  z-index: 25;
+  display: flex;
+  justify-content: center;
+  padding: 0 12px;
+  pointer-events: none;
+  margin-top: -32px;
+  margin-bottom: -32px;
+}
+
+.webtoon-lock-card {
+  background: #fffcf9;
+  border: 3px solid #000;
+  border-radius: 12px;
+  padding: 18px 22px;
+  box-shadow: 6px 6px 0 rgba(0, 0, 0, .35);
+  pointer-events: auto;
+  max-width: 360px;
+  text-align: center;
+}
+
+.webtoon-lock-title {
+  font-size: 18px;
+  font-weight: 800;
+  margin-bottom: 8px;
+  color: #222;
+  letter-spacing: .02em;
+}
+
+.webtoon-lock-desc {
+  font-size: 13px;
+  line-height: 1.6;
+  color: #444;
+}
+
+.webtoon-lock-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 88px;
+  transform: translateX(-50%);
+  background: rgba(20, 20, 30, .92);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 700;
+  z-index: 46;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .35);
+  pointer-events: none;
+  animation: webtoonLockToastFade .3s ease-out;
+}
+
+@keyframes webtoonLockToastFade {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+/* モバイル縦読みでは launcher コマを常時グロー */
+@media (max-width: 768px) {
+  .webtoon-page .koma.launcher {
+    filter: drop-shadow(0 0 10px rgba(255, 213, 0, .35))
+            drop-shadow(0 0 24px rgba(255, 213, 0, .22));
+    animation: glow-breathe 2.4s ease-in-out infinite;
+  }
+}
+
+@media (max-width: 768px) and (prefers-reduced-motion: reduce) {
+  .webtoon-page .koma.launcher {
+    animation: none;
+  }
+}
+
+.webtoon-camera.zooming-in { animation: webtoonZoomIn .7s ease-out forwards; }
+.webtoon-camera.zooming-out { animation: webtoonZoomOut .7s ease-out forwards; }
+
+@keyframes webtoonZoomIn {
+  0% { transform: scale(1) translateZ(0); }
+  100% { transform: scale(10) translateZ(0); }
+}
+
+@keyframes webtoonZoomOut {
+  0% { transform: scale(10) translateZ(0); }
+  100% { transform: scale(1) translateZ(0); }
 }
 
 /* 余白 */

--- a/InteractiveManga/app/page.tsx
+++ b/InteractiveManga/app/page.tsx
@@ -1,5 +1,5 @@
-import MangaBook from '@/components/MangaBook';
+import MangaApp from '@/components/MangaApp';
 
 export default function Home() {
-  return <MangaBook />;
+  return <MangaApp />;
 }

--- a/InteractiveManga/components/AIBot.tsx
+++ b/InteractiveManga/components/AIBot.tsx
@@ -1,126 +1,102 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { buildDialogue, ChoiceId } from '@/lib/aiBotDialogue';
 
 interface AIBotProps {
   isActive: boolean;
   onClose: () => void;
+  onComplete?: () => void;
 }
 
-const AIBot: React.FC<AIBotProps> = ({ isActive, onClose }) => {
-  const [userInput, setUserInput] = useState('');
-  const [responseText, setResponseText] = useState('お前、この仕事やってて楽しいか？');
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [showResponse, setShowResponse] = useState(false);
-  const [messageCount, setMessageCount] = useState(0);
+const AIBot: React.FC<AIBotProps> = ({ isActive, onClose, onComplete }) => {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [choice, setChoice] = useState<ChoiceId | null>(null);
 
   useEffect(() => {
     if (isActive) {
-      setShowResponse(true);
-      setResponseText('お前、この仕事やってて楽しいか？');
-    } else {
-      setShowResponse(false);
-      setUserInput('');
-      setResponseText('');
-      setMessageCount(0); // Reset message count when closing
+      setStepIndex(0);
+      setChoice(null);
     }
   }, [isActive]);
 
+  const steps = useMemo(() => buildDialogue(choice), [choice]);
+  const currentStep = steps[stepIndex];
+  const isFinished = !currentStep;
 
-  const sendMessage = async () => {
-    const message = userInput.trim();
-    if (!message) return;
-
-    // Check message limit
-    if (messageCount >= 3) {
-      setResponseText('回答の制限回数に達しました。これ以上質問はできません。');
-      setShowResponse(true);
-      return;
+  useEffect(() => {
+    if (isActive && isFinished) {
+      onComplete?.();
+      onClose();
     }
+  }, [isActive, isFinished, onComplete, onClose]);
 
-    setIsProcessing(true);
-    setShowResponse(false);
-
-    setTimeout(() => {
-      setResponseText('考え中…');
-      setShowResponse(true);
-    }, 80);
-
-    try {
-      const response = await fetch('/api/chat', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ message }),
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to get response');
-      }
-
-      const data = await response.json();
-      setResponseText(data.response);
-      setMessageCount(prevCount => prevCount + 1); // Increment message count
-    } catch (error) {
-      console.error('Error:', error);
-      setResponseText('エラーが発生しました。もう一度お試しください。');
-    } finally {
-      setIsProcessing(false);
-      setUserInput('');
+  const advance = useCallback(() => {
+    if (isFinished) return;
+    if (currentStep.kind === 'message') {
+      setStepIndex((prev) => prev + 1);
     }
-  };
+  }, [currentStep, isFinished]);
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      sendMessage();
-    }
-  };
+  const selectChoice = useCallback((id: ChoiceId) => {
+    setChoice(id);
+    setStepIndex((prev) => prev + 1);
+  }, []);
+
+  const handleBoxClick = useCallback(() => {
+    if (currentStep?.kind === 'message' || isFinished) advance();
+  }, [currentStep, isFinished, advance]);
 
   return (
     <>
-      <div className={`ai-bot-wrapper ${isActive ? 'active' : ''}`} id="aiBotWrapper">
+      <div className={`ai-bot-wrapper ${isActive ? 'active' : ''}`}>
         <div className="ai-bot-container">
-          <div className="image-background" id="imageBackground" />
-          <div className="message-counter">
-            残り回答回数: {3 - messageCount}回
-          </div>
-          <div className={`ai-response-area ${showResponse ? 'show' : ''}`} id="aiResponseArea">
-            <div className="ai-response-text" id="aiResponseText">
-              {responseText}
-            </div>
-          </div>
-          <div className="input-area">
-            <div className="input-container">
-              <input
-                type="text"
-                className="text-input"
-                id="userInput"
-                placeholder={messageCount >= 3 ? "回答制限に達しました" : "上司に回答する…"}
-                autoComplete="off"
-                value={userInput}
-                onChange={(e) => setUserInput(e.target.value)}
-                onKeyPress={handleKeyPress}
-                disabled={isProcessing || messageCount >= 3}
-              />
-              <button
-                className="submit-btn"
-                id="submitBtn"
-                type="button"
-                onClick={sendMessage}
-                disabled={isProcessing || messageCount >= 3}
+          <div className="image-background" />
+
+          <div
+            className="ai-dialogue-box"
+            onClick={handleBoxClick}
+            role="dialog"
+            aria-label="営業部長との会話"
+          >
+            <div className="ai-dialogue-speaker">営業部長</div>
+
+            {currentStep?.kind === 'message' && (
+              <>
+                <div className="ai-dialogue-text">{currentStep.text}</div>
+                <div className="ai-dialogue-next" aria-hidden="true">
+                  ▼ タップで次へ
+                </div>
+              </>
+            )}
+
+            {currentStep?.kind === 'choice' && (
+              <div
+                className="ai-choice-list"
+                onClick={(e) => e.stopPropagation()}
               >
-                {messageCount >= 3 ? '制限到達' : isProcessing ? '処理中' : '回答'}
-              </button>
-            </div>
+                <div className="ai-choice-prompt">どう答える？</div>
+                {currentStep.options.map((opt) => (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    className="ai-choice-btn"
+                    onClick={() => selectChoice(opt.id)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            )}
+
           </div>
         </div>
       </div>
       <span
         className={`back-btn ${isActive ? 'visible' : ''}`}
-        id="backBtn"
         onClick={onClose}
+        role="button"
+        aria-label="閉じる"
       >
         &times;
       </span>

--- a/InteractiveManga/components/KomaPanel.tsx
+++ b/InteractiveManga/components/KomaPanel.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import { getLauncherTarget, LauncherTarget } from '@/lib/gameLaunchers';
+
+export interface KomaPanelProps {
+  pageNum: number;
+  komaNum: number;
+  assetName: string;
+  className?: string;
+  hasUfoPrize: boolean;
+  isFreshUfoPrize: boolean;
+  onLaunch: (el: HTMLElement, target: LauncherTarget) => void;
+  loadingStrategy?: 'eager' | 'lazy';
+}
+
+const KomaPanel: React.FC<KomaPanelProps> = ({
+  pageNum,
+  komaNum,
+  assetName,
+  className = '',
+  hasUfoPrize,
+  isFreshUfoPrize,
+  onLaunch,
+  loadingStrategy = 'eager',
+}) => {
+  const isPrizeUnlocked = pageNum === 4 && (komaNum === 3 || komaNum === 4) && hasUfoPrize;
+  const finalClassName = `koma ${className}${isPrizeUnlocked ? ' prize-unlocked' : ''}${
+    isPrizeUnlocked && isFreshUfoPrize ? ' prize-fresh' : ''
+  }`;
+  const target = getLauncherTarget(pageNum, komaNum);
+
+  return (
+    <div
+      className={finalClassName}
+      data-koma={komaNum}
+      data-asset={assetName}
+      onClick={(e) => {
+        if (!target) return;
+        onLaunch(e.currentTarget as HTMLDivElement, target);
+      }}
+    >
+      <img
+        className="koma-img-el"
+        alt={assetName}
+        data-name={assetName}
+        src={`/images/${assetName}.png`}
+        loading={loadingStrategy}
+        decoding="async"
+      />
+    </div>
+  );
+};
+
+export default KomaPanel;

--- a/InteractiveManga/components/MangaApp.tsx
+++ b/InteractiveManga/components/MangaApp.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import React from 'react';
+import dynamic from 'next/dynamic';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+const MangaBook = dynamic(() => import('./MangaBook'), { ssr: false });
+const MangaWebtoon = dynamic(() => import('./MangaWebtoon'), { ssr: false });
+
+const MangaApp: React.FC = () => {
+  const isMobile = useIsMobile();
+
+  if (isMobile === null) {
+    return null;
+  }
+
+  return isMobile ? <MangaWebtoon /> : <MangaBook />;
+};
+
+export default MangaApp;

--- a/InteractiveManga/components/MangaBook.tsx
+++ b/InteractiveManga/components/MangaBook.tsx
@@ -1,269 +1,73 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import AIBot from './AIBot';
 import MiniGameModal from './MiniGameModal';
+import SharedKomaPanel, { KomaPanelProps } from './KomaPanel';
+import { useGameLauncher } from '@/hooks/useGameLauncher';
+import { useGameProgress } from '@/hooks/useGameProgress';
+import { usePageTurnSound } from '@/hooks/usePageTurnSound';
+
+type KomaProps = Omit<KomaPanelProps, 'hasUfoPrize' | 'isFreshUfoPrize' | 'onLaunch'>;
+
+const TOTAL_SPREADS = 7;
 
 const MangaBook: React.FC = () => {
   const [currentSpread, setCurrentSpread] = useState(1);
-  const [isAIBotOpen, setIsAIBotOpen] = useState(false);
-  const [isMiniGameOpen, setIsMiniGameOpen] = useState(false);
-  const [currentGameUrl, setCurrentGameUrl] = useState('');
-  const [currentGameTitle, setCurrentGameTitle] = useState('');
-  const [isMiniGameFullScreen, setIsMiniGameFullScreen] = useState(false);
-  const [isPageSoundOn, setIsPageSoundOn] = useState(true);
-  const cleanupTimerRef = useRef<number | null>(null);
-  const prizeRevealTimerRef = useRef<number | null>(null);
-  const prizeFreshResetTimerRef = useRef<number | null>(null);
-  const totalSpreads = 7;
 
-  // UFOキャッチャーの景品獲得状態
-  const [hasUfoPrize, setHasUfoPrize] = useState(false);
-  const [pendingUfoPrize, setPendingUfoPrize] = useState(false);
-  const [isFreshUfoPrize, setIsFreshUfoPrize] = useState(false);
-
-  // テトリスのスコア達成状態
-  const [hasTetrisScore, setHasTetrisScore] = useState(false);
-
-  // Zoom animation state
   const cameraRef = useRef<HTMLDivElement>(null);
-  const [isZoomingIn, setIsZoomingIn] = useState(false);
-  const [isZoomingOut, setIsZoomingOut] = useState(false);
-  const [isZoomed, setIsZoomed] = useState(false);
-  const [isZoomOverlayActive, setIsZoomOverlayActive] = useState(false);
-
-  // Page-turn SE
-  const pageTurnAudioRef = useRef<HTMLAudioElement | null>(null);
-  const playPageTurnSE = () => {
-    if (!isPageSoundOn) return;
-    const el = pageTurnAudioRef.current;
-    if (!el) return;
-    try { el.currentTime = 0; } catch (_) {}
-    el.play().catch(() => {});
-  };
+  const sound = usePageTurnSound();
+  const progress = useGameProgress();
+  const launcher = useGameLauncher({
+    cameraRef,
+    onUfoPrizeCollected: progress.markPendingUfoPrize,
+    onTetrisScoreAchieved: progress.markTetrisScore,
+  });
 
   const showSpread = (n: number) => {
-    if (isAIBotOpen || isMiniGameOpen || isZoomingIn || isZoomingOut) return;
+    if (launcher.isBusy) return;
     if (n === currentSpread) return;
     setCurrentSpread(n);
-    playPageTurnSE();
+    sound.play();
   };
 
   const nextSpread = () => {
-    if (isAIBotOpen || isMiniGameOpen || isZoomingIn || isZoomingOut) return;
-    // 見開き5（ページ7）から次に進む場合、テトリススコア300以上が必要
-    if (currentSpread === 5 && !hasTetrisScore) {
-      // スコア未達成の場合は進めない
-      return;
-    }
-    if (currentSpread < totalSpreads) showSpread(currentSpread + 1);
+    if (launcher.isBusy) return;
+    if (currentSpread === 3 && !progress.hasCompletedAIBot) return;
+    if (currentSpread === 5 && !progress.hasTetrisScore) return;
+    if (currentSpread < TOTAL_SPREADS) showSpread(currentSpread + 1);
   };
 
   const prevSpread = () => {
-    if (isAIBotOpen || isMiniGameOpen || isZoomingIn || isZoomingOut) return;
+    if (launcher.isBusy) return;
     if (currentSpread > 1) showSpread(currentSpread - 1);
   };
 
-  // ズームアウトを実行
-  const performZoomOut = () => {
-    if (cameraRef.current) {
-      cameraRef.current.classList.remove('zooming-in');
-      cameraRef.current.classList.add('zooming-out');
+  useEffect(() => {
+    const canReveal = !launcher.zoom.isZoomingOut && !launcher.zoom.isZoomed;
+    progress.finalizePendingUfoPrize(canReveal);
+  }, [launcher.zoom.isZoomingOut, launcher.zoom.isZoomed, progress.finalizePendingUfoPrize]);
+
+  useEffect(() => {
+    if (currentSpread !== 4 && progress.isFreshUfoPrize) {
+      progress.clearFreshUfoPrize();
     }
-    setIsZoomingIn(false);
-    setIsZoomingOut(true);
-    setIsZoomOverlayActive(false);
-    // アニメーション終了でリセット
-    cleanupTimerRef.current && window.clearTimeout(cleanupTimerRef.current);
-    cleanupTimerRef.current = window.setTimeout(() => {
-      if (cameraRef.current) {
-        cameraRef.current.classList.remove('zooming-out');
-      }
-      setIsZoomed(false);
-      setIsZoomingOut(false);
-      // スクロール復帰
-      try { document.body.style.overflow = ''; } catch (_) {}
-    }, 720);
-  };
-
-  // 閉じ処理（ズーム演出あり）
-  const closeActiveUI = () => {
-    // UIを閉じる（モーダルは内部でフェードアウト）
-    setIsMiniGameOpen(false);
-    setIsAIBotOpen(false);
-    setCurrentGameUrl('');
-    setCurrentGameTitle('');
-    setIsMiniGameFullScreen(false);
-    // 表示中ならズームアウト
-    if (isZoomed || isZoomingIn) {
-      performZoomOut();
-    }
-  };
-
-  useEffect(() => {
-    //  iFrame内ミニゲームからの終了要求（×ボタンなど）を受け取る
-    const handleMessage = (e: MessageEvent) => {
-      try {
-        if (e.origin !== window.location.origin) return;
-      } catch (_) {}
-      if (e && (e as any).data && (e as any).data.type === 'CLOSE_MINI_GAME') {
-        closeActiveUI();
-      }
-      // UFOキャッチャーからの景品獲得通知
-      if (e && (e as any).data && (e as any).data.type === 'UFO_PRIZE_COLLECTED') {
-        const count = (e as any).data.count || 0;
-        if (count >= 1) {
-          // 現在の状態を確認してから処理
-          setPendingUfoPrize(prevPending => {
-            if (!prevPending) {
-              // ズームアウト完了後に表示するためのフラグを立てる
-              return true;
-            }
-            return prevPending;
-          });
-        }
-      }
-      // テトリスからのスコア達成通知
-      if (e && (e as any).data && (e as any).data.type === 'TETRIS_SCORE_ACHIEVED') {
-        setHasTetrisScore(prevScore => {
-          if (!prevScore) {
-            try {
-              localStorage.setItem('hasTetrisScore', 'true');
-            } catch (_) {}
-            return true;
-          }
-          return prevScore;
-        });
-      }
-    };
-
-    window.addEventListener('message', handleMessage);
-    return () => {
-      window.removeEventListener('message', handleMessage);
-      // Clean up any pending timers on unmount
-      if (cleanupTimerRef.current) {
-        window.clearTimeout(cleanupTimerRef.current);
-      }
-      if (prizeRevealTimerRef.current) {
-        window.clearTimeout(prizeRevealTimerRef.current);
-        prizeRevealTimerRef.current = null;
-      }
-      if (prizeFreshResetTimerRef.current) {
-        window.clearTimeout(prizeFreshResetTimerRef.current);
-        prizeFreshResetTimerRef.current = null;
-      }
-    };
-  }, []);
-
-  // Prepare page-turn audio element
-  useEffect(() => {
-    // Use public/ served path
-    const el = new Audio('/sounds/ThumbThrough.mp3');
-    try { el.preload = 'auto'; } catch (_) {}
-    // Volume: make page-turn sound a bit quieter
-    try { el.volume = 0.25; } catch (_) {}
-    pageTurnAudioRef.current = el;
-    return () => {
-      try { el.pause(); } catch (_) {}
-      // Detach source to hint GC
-      try { el.src = ''; } catch (_) {}
-      pageTurnAudioRef.current = null;
-    };
-  }, []);
-
-  // Optionally restore saved preference
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem('pageSoundOn');
-      if (saved != null) setIsPageSoundOn(saved === '1');
-    } catch (_) {}
-  }, []);
-
-  // UFOキャッチャーの景品獲得状態を復元
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem('hasUfoPrize');
-      if (saved === 'true') setHasUfoPrize(true);
-    } catch (_) {}
-  }, []);
-
-  // テトリスのスコア達成状態を復元
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem('hasTetrisScore');
-      if (saved === 'true') setHasTetrisScore(true);
-    } catch (_) {}
-  }, []);
-
-  // Persist preference on change
-  useEffect(() => {
-    try { localStorage.setItem('pageSoundOn', isPageSoundOn ? '1' : '0'); } catch (_) {}
-  }, [isPageSoundOn]);
-
-  // ズームアウト完了後に景品獲得状態を反映（一拍置いてから表示）
-  useEffect(() => {
-    if (!isZoomingOut && !isZoomed && pendingUfoPrize && !hasUfoPrize) {
-      if (prizeRevealTimerRef.current) {
-        window.clearTimeout(prizeRevealTimerRef.current);
-      }
-      prizeRevealTimerRef.current = window.setTimeout(() => {
-        prizeRevealTimerRef.current = null;
-        setIsFreshUfoPrize(true);
-        setHasUfoPrize(true);
-        setPendingUfoPrize(false);
-        try {
-          localStorage.setItem('hasUfoPrize', 'true');
-        } catch (_) {}
-
-        if (prizeFreshResetTimerRef.current) {
-          window.clearTimeout(prizeFreshResetTimerRef.current);
-        }
-        prizeFreshResetTimerRef.current = window.setTimeout(() => {
-          setIsFreshUfoPrize(false);
-          prizeFreshResetTimerRef.current = null;
-        }, 1800);
-      }, 600);
-    }
-    
-    // Single cleanup function that handles both timers
-    return () => {
-      if (prizeRevealTimerRef.current) {
-        window.clearTimeout(prizeRevealTimerRef.current);
-        prizeRevealTimerRef.current = null;
-      }
-      if (prizeFreshResetTimerRef.current) {
-        window.clearTimeout(prizeFreshResetTimerRef.current);
-        prizeFreshResetTimerRef.current = null;
-      }
-    };
-  }, [isZoomingOut, isZoomed, pendingUfoPrize, hasUfoPrize]);
-
-  // ページを離れたタイミングで浮かび上がりアニメーションを確実に解除
-  useEffect(() => {
-    if (currentSpread !== 4 && isFreshUfoPrize) {
-      if (prizeFreshResetTimerRef.current) {
-        window.clearTimeout(prizeFreshResetTimerRef.current);
-        prizeFreshResetTimerRef.current = null;
-      }
-      setIsFreshUfoPrize(false);
-    }
-  }, [currentSpread, isFreshUfoPrize]);
+  }, [currentSpread, progress.isFreshUfoPrize, progress.clearFreshUfoPrize]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // UI表示中はEscで閉じる、ナビは抑止
-      if (isAIBotOpen || isMiniGameOpen) {
-        if (e.key === 'Escape') closeActiveUI();
+      if (launcher.active.isAIBotOpen || launcher.active.isMiniGameOpen) {
+        if (e.key === 'Escape') launcher.closeActive();
         return;
       }
-      // Reading flow: Right arrow => next, Left arrow => previous
       if (e.key === 'ArrowRight') nextSpread();
       else if (e.key === 'ArrowLeft') prevSpread();
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isAIBotOpen, isMiniGameOpen, currentSpread]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [launcher.active.isAIBotOpen, launcher.active.isMiniGameOpen, currentSpread]);
 
   useEffect(() => {
     let startX = 0;
@@ -289,347 +93,287 @@ const MangaBook: React.FC = () => {
       document.removeEventListener('touchstart', handleTouchStart);
       document.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [currentSpread, isAIBotOpen, isMiniGameOpen]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSpread, launcher.active.isAIBotOpen, launcher.active.isMiniGameOpen]);
 
-  // クリックしたコマの中心へズーム → アプリ起動
-  const launchWithZoom = (el: HTMLDivElement, launchFn: () => void) => {
-    if (!el || isZoomingIn || isZoomingOut || isAIBotOpen || isMiniGameOpen) return;
-    const rect = el.getBoundingClientRect();
-    const cx = rect.left + rect.width / 2;
-    const cy = rect.top + rect.height / 2;
-    if (cameraRef.current) {
-      cameraRef.current.style.setProperty('--zoom-origin-x', `${cx}px`);
-      cameraRef.current.style.setProperty('--zoom-origin-y', `${cy}px`);
-      // ズーム開始
-      cameraRef.current.classList.add('zooming-in');
-    }
-    setIsZoomOverlayActive(true);
-    setIsZoomingIn(true);
-    try { document.body.style.overflow = 'hidden'; } catch (_) {}
-
-    // 起動パネルの軽いエフェクト
-    el.classList.add('launching');
-    window.setTimeout(() => el.classList.remove('launching'), 550);
-
-    // ズーム完了直前にアプリ起動
-    cleanupTimerRef.current && window.clearTimeout(cleanupTimerRef.current);
-    cleanupTimerRef.current = window.setTimeout(() => {
-      setIsZoomed(true);
-      setIsZoomingIn(false);
-      launchFn();
-    }, 620);
-  };
-
-
-  const KomaPanel = ({ pageNum, komaNum, assetName, className = "" }: {
-    pageNum: number;
-    komaNum: number;
-    assetName: string;
-    className?: string;
-  }) => {
-    // ページ4のコマ3とコマ4に景品獲得状態に応じてクラスを追加
-    const isPrizeUnlocked = pageNum === 4 && (komaNum === 3 || komaNum === 4) && hasUfoPrize;
-    const finalClassName = `koma ${className}${isPrizeUnlocked ? ' prize-unlocked' : ''}${isPrizeUnlocked && isFreshUfoPrize ? ' prize-fresh' : ''}`;
-
-    return (
-    <div
-      className={finalClassName}
-      data-koma={komaNum}
-      data-asset={assetName}
-      onClick={(e) => {
-        const el = e.currentTarget as HTMLDivElement;
-        // 起動対象かどうか判定（ズーム→起動）
-        if (pageNum === 3 && komaNum === 1) {
-          launchWithZoom(el, () => {
-            setIsAIBotOpen(true);
-            setCurrentGameUrl('');
-            setCurrentGameTitle('');
-            setIsMiniGameFullScreen(false);
-          });
-        } else if (pageNum === 7 && komaNum === 5) {
-          launchWithZoom(el, () => {
-            setIsAIBotOpen(false);
-            setCurrentGameUrl('/mini-games/p7_koma5_tetris.html');
-            setCurrentGameTitle('Tetris');
-            setIsMiniGameFullScreen(true);
-            setIsMiniGameOpen(true);
-          });
-        } else if (pageNum === 6 && komaNum === 4) {
-          launchWithZoom(el, () => {
-            setIsAIBotOpen(false);
-            setCurrentGameUrl('/mini-games/p6_koma4_bubble.html');
-            setCurrentGameTitle('Interactive Bubbles');
-            setIsMiniGameFullScreen(true);
-            setIsMiniGameOpen(true);
-          });
-        } else if (pageNum === 4 && komaNum === 5) {
-          launchWithZoom(el, () => {
-            setIsAIBotOpen(false);
-            setCurrentGameUrl('/mini-games/p4_koma5_ufo.html');
-            setCurrentGameTitle('UFO Catcher');
-            setIsMiniGameFullScreen(true);
-            setIsMiniGameOpen(true);
-          });
-        } else if (pageNum === 9 && komaNum === 4) {
-          launchWithZoom(el, () => {
-            setIsAIBotOpen(false);
-            setCurrentGameUrl('/mini-games/p9_koma4_shooting.html');
-            setCurrentGameTitle('Shooting');
-            setIsMiniGameFullScreen(true);
-            setIsMiniGameOpen(true);
-          });
-        } else if (pageNum === 2 && komaNum === 1) {
-          launchWithZoom(el, () => {
-            setIsAIBotOpen(false);
-            setCurrentGameUrl('/mini-games/p2_koma1_email.html');
-            setCurrentGameTitle('Email');
-            setIsMiniGameFullScreen(true);
-            setIsMiniGameOpen(true);
-          });
-        }
-      }}
-    >
-      <img
-        className="koma-img-el"
-        alt={assetName}
-        data-name={assetName}
-        src={`/images/${assetName}.png`}
-        loading="eager"
-        decoding="async"
-      />
-    </div>
-    );
-  };
+  const KomaPanel = (props: KomaProps) => (
+    <SharedKomaPanel
+      {...props}
+      hasUfoPrize={progress.hasUfoPrize}
+      isFreshUfoPrize={progress.isFreshUfoPrize}
+      onLaunch={launcher.launchAt}
+    />
+  );
 
   return (
     <>
-      {/* カメラズーム用コンテナで本体をラップ */}
-      <div className={`camera-zoom-container${isZoomingIn ? ' zooming-in' : ''}${isZoomingOut ? ' zooming-out' : ''}`} id="cameraZoomContainer" ref={cameraRef}>
-      <div className="book-container" id="bookRoot">
+      <div
+        className={`camera-zoom-container${launcher.zoom.isZoomingIn ? ' zooming-in' : ''}${
+          launcher.zoom.isZoomingOut ? ' zooming-out' : ''
+        }`}
+        id="cameraZoomContainer"
+        ref={cameraRef}
+      >
+        <div className="book-container" id="bookRoot">
           {/* 見開き1（表紙） */}
-        <div className={`spread has-empty ${currentSpread === 1 ? 'active' : ''}`} data-spread="1">
-          <div className="page left">
-            <div className="cover-container has-image" id="front-cover" data-asset="cover_front">
-              <img
-                className="cover-image koma-img-el"
-                alt="cover_front"
-                data-name="cover_front"
-                src="/images/cover_front.png"
-                style={{ display: 'block' }}
-              />
+          <div
+            className={`spread has-empty ${currentSpread === 1 ? 'active' : ''}`}
+            data-spread="1"
+          >
+            <div className="page left">
+              <div className="cover-container has-image" id="front-cover" data-asset="cover_front">
+                <img
+                  className="cover-image koma-img-el"
+                  alt="cover_front"
+                  data-name="cover_front"
+                  src="/images/cover_front.png"
+                  style={{ display: 'block' }}
+                />
+              </div>
+              <div className="nav-area next" onClick={nextSpread} />
             </div>
-            <div className="nav-area next" onClick={nextSpread} />
+            <div className="page right empty" />
           </div>
-          <div className="page right empty" />
-        </div>
 
-        {/* 見開き2：ページ1 + 表紙裏 */}
-        <div className={`spread ${currentSpread === 2 ? 'active' : ''}`} data-spread="2">
-          <div className="page left">
-            <div className="manga-page layout-p1v2" data-page="1">
-              <div className="row top">
-                <KomaPanel pageNum={1} komaNum={1} assetName="p1_koma1" />
-                <KomaPanel pageNum={1} komaNum={2} assetName="p1_koma2" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={1} komaNum={3} assetName="p1_koma3" />
-              </div>
-            </div>
-            <div className="nav-area next" onClick={nextSpread} />
-          </div>
-          <div className="page right">
-            <div className="front-inside">
-              <div className="qr-code-area" aria-label="QR" />
-            </div>
-            <div className="nav-area prev" onClick={prevSpread} />
-          </div>
-        </div>
-
-        {/* 見開き3：ページ3（左）+ ページ2（右） */}
-        <div className={`spread ${currentSpread === 3 ? 'active' : ''}`} data-spread="3">
-          <div className="page left">
-            <div className="manga-page layout-p3v2" data-page="3">
-              <div className="row top">
-                <KomaPanel pageNum={3} komaNum={1} assetName="p3_koma1" className="launcher" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={3} komaNum={2} assetName="p3_koma2" />
-              </div>
-            </div>
-            <div className="nav-area next" onClick={nextSpread} />
-          </div>
-          <div className="page right">
-            <div className="manga-page layout-p2v2" data-page="2">
-              <div className="row top">
-                <KomaPanel pageNum={2} komaNum={1} assetName="p2_koma1" className="full launcher" />
-              </div>
-              <div className="row mid">
-                <KomaPanel pageNum={2} komaNum={2} assetName="p2_koma2" className="left" />
-                <KomaPanel pageNum={2} komaNum={3} assetName="p2_koma3" className="thin" />
-                <KomaPanel pageNum={2} komaNum={4} assetName="p2_koma4" className="right" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={2} komaNum={5} assetName="p2_koma5" />
-                <KomaPanel pageNum={2} komaNum={6} assetName="p2_koma6" />
-              </div>
-            </div>
-            <div className="nav-area prev" onClick={prevSpread} />
-          </div>
-        </div>
-
-        {/* 見開き4：ページ5（左） + ページ4（右） */}
-        <div className={`spread ${currentSpread === 4 ? 'active' : ''}`} data-spread="4">
-          <div className="page left">
-            <div className="manga-page layout-p5" data-page="5">
-              <div className="row top">
-                <KomaPanel pageNum={5} komaNum={1} assetName="p5_koma1" />
-                <KomaPanel pageNum={5} komaNum={2} assetName="p5_koma2" />
-              </div>
-              <div className="row mid">
-                <KomaPanel pageNum={5} komaNum={3} assetName="p5_koma3" />
-                <KomaPanel pageNum={5} komaNum={4} assetName="p5_koma4" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={5} komaNum={5} assetName="p5_koma5" />
-              </div>
-            </div>
-            <div className="nav-area next" onClick={nextSpread} />
-          </div>
-          <div className="page right">
-            <div className="manga-page layout-p4v2" data-page="4">
-              <KomaPanel pageNum={4} komaNum={1} assetName="p4_koma1" className="k1" />
-              <KomaPanel pageNum={4} komaNum={2} assetName="p4_koma2" className="k2" />
-              <KomaPanel pageNum={4} komaNum={3} assetName="p4_koma3" className="k3" />
-              <KomaPanel pageNum={4} komaNum={4} assetName="p4_koma4" className="k4" />
-              <KomaPanel pageNum={4} komaNum={5} assetName="p4_koma5" className="k5 launcher" />
-            </div>
-            <div className="nav-area prev" onClick={prevSpread} />
-          </div>
-        </div>
-
-        {/* 見開き5：ページ7（左） + ページ6（右） */}
-        <div className={`spread ${currentSpread === 5 ? 'active' : ''}`} data-spread="5">
-          <div className="page left">
-            <div className="manga-page layout-p7b" data-page="7">
-              <div className="row top">
-                <KomaPanel pageNum={7} komaNum={1} assetName="p7_koma1" className="k1" />
-                <KomaPanel pageNum={7} komaNum={2} assetName="p7_koma2" className="k2" />
-              </div>
-              <div className="row mid">
-                <KomaPanel pageNum={7} komaNum={3} assetName="p7_koma3" className="k3" />
-                <KomaPanel pageNum={7} komaNum={4} assetName="p7_koma4" className="k4" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={7} komaNum={5} assetName="p7_koma5" className="k5 launcher" />
-              </div>
-            </div>
-            <div
-              className={`nav-area next${currentSpread === 5 && !hasTetrisScore ? ' tetris-locked' : ''}`}
-              onClick={nextSpread}
-            >
-              {currentSpread === 5 && !hasTetrisScore && (
-                <div className="tetris-requirement-tooltip">
-                  Tetris Over 300 point
+          {/* 見開き2：ページ1 + 表紙裏 */}
+          <div className={`spread ${currentSpread === 2 ? 'active' : ''}`} data-spread="2">
+            <div className="page left">
+              <div className="manga-page layout-p1v2" data-page="1">
+                <div className="row top">
+                  <KomaPanel pageNum={1} komaNum={1} assetName="p1_koma1" />
+                  <KomaPanel pageNum={1} komaNum={2} assetName="p1_koma2" />
                 </div>
-              )}
+                <div className="row bottom">
+                  <KomaPanel pageNum={1} komaNum={3} assetName="p1_koma3" />
+                </div>
+              </div>
+              <div className="nav-area next" onClick={nextSpread} />
+            </div>
+            <div className="page right">
+              <div className="front-inside">
+                <div className="qr-code-area" aria-label="QR" />
+              </div>
+              <div className="nav-area prev" onClick={prevSpread} />
             </div>
           </div>
-          <div className="page right">
-            <div className="manga-page layout-p6" data-page="6">
-              <div className="row top">
-                <KomaPanel pageNum={6} komaNum={1} assetName="p6_koma1" />
-                <KomaPanel pageNum={6} komaNum={2} assetName="p6_koma2" />
-                <KomaPanel pageNum={6} komaNum={3} assetName="p6_koma3" />
-              </div>
-              <div className="row mid">
-                <KomaPanel pageNum={6} komaNum={4} assetName="p6_koma4" className="launcher" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={6} komaNum={5} assetName="p6_koma5" />
-                <KomaPanel pageNum={6} komaNum={6} assetName="p6_koma6" />
-              </div>
-            </div>
-            <div className="nav-area prev" onClick={prevSpread} />
-          </div>
-        </div>
 
-        {/* 見開き6：ページ9（左） + ページ8（右） */}
-        <div className={`spread ${currentSpread === 6 ? 'active' : ''}`} data-spread="6">
-          <div className="page left">
-            <div className="manga-page layout-p9" data-page="9">
-              <div className="row top">
-                <KomaPanel pageNum={9} komaNum={1} assetName="p9_koma1" />
-                <KomaPanel pageNum={9} komaNum={2} assetName="p9_koma2" />
+          {/* 見開き3：ページ3（左）+ ページ2（右） */}
+          <div className={`spread ${currentSpread === 3 ? 'active' : ''}`} data-spread="3">
+            <div className="page left">
+              <div className="manga-page layout-p3v2" data-page="3">
+                <div className="row top">
+                  <KomaPanel pageNum={3} komaNum={1} assetName="p3_koma1" className="launcher" />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={3} komaNum={2} assetName="p3_koma2" />
+                </div>
               </div>
-              <div className="row mid">
-                <KomaPanel pageNum={9} komaNum={3} assetName="p9_koma3" />
-                <KomaPanel pageNum={9} komaNum={4} assetName="p9_koma4" className="launcher" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={9} komaNum={5} assetName="p9_koma5" />
-                <KomaPanel pageNum={9} komaNum={6} assetName="p9_koma6" />
-              </div>
-            </div>
-            <div className="nav-area next" onClick={nextSpread} />
-          </div>
-          <div className="page right">
-            <div className="manga-page layout-p7" data-page="8">
-              <div className="row top">
-                <KomaPanel pageNum={8} komaNum={1} assetName="p8_koma1" className="left" />
-                <KomaPanel pageNum={8} komaNum={2} assetName="p8_koma2" className="right" />
-              </div>
-              <div className="row mid">
-                <KomaPanel pageNum={8} komaNum={3} assetName="p8_koma3" />
-              </div>
-              <div className="row bottom">
-                <KomaPanel pageNum={8} komaNum={4} assetName="p8_koma4" />
-                <KomaPanel pageNum={8} komaNum={5} assetName="p8_koma5" />
+              <div
+                className={`nav-area next${
+                  currentSpread === 3 && !progress.hasCompletedAIBot ? ' aibot-locked' : ''
+                }`}
+                onClick={nextSpread}
+              >
+                {currentSpread === 3 && !progress.hasCompletedAIBot && (
+                  <div className="tetris-requirement-tooltip">Talk to your boss first</div>
+                )}
               </div>
             </div>
-            <div className="nav-area prev" onClick={prevSpread} />
+            <div className="page right">
+              <div className="manga-page layout-p2v2" data-page="2">
+                <div className="row top">
+                  <KomaPanel
+                    pageNum={2}
+                    komaNum={1}
+                    assetName="p2_koma1"
+                    className="full launcher"
+                  />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={2} komaNum={2} assetName="p2_koma2" className="left" />
+                  <KomaPanel pageNum={2} komaNum={3} assetName="p2_koma3" className="thin" />
+                  <KomaPanel pageNum={2} komaNum={4} assetName="p2_koma4" className="right" />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={2} komaNum={5} assetName="p2_koma5" />
+                  <KomaPanel pageNum={2} komaNum={6} assetName="p2_koma6" />
+                </div>
+              </div>
+              <div className="nav-area prev" onClick={prevSpread} />
+            </div>
           </div>
-        </div>
 
-        {/* 見開き7：裏表紙 */}
-        <div className={`spread has-empty ${currentSpread === 7 ? 'active' : ''}`} data-spread="7">
-          <div className="page left empty" />
-          <div className="page right">
-            <div className="cover-container has-image" id="back-cover" data-asset="cover_back">
-              <img
-                className="cover-image koma-img-el"
-                alt="cover_back"
-                data-name="cover_back"
-                src="/images/cover_back.png"
-                style={{ display: 'block' }}
-              />
+          {/* 見開き4：ページ5（左） + ページ4（右） */}
+          <div className={`spread ${currentSpread === 4 ? 'active' : ''}`} data-spread="4">
+            <div className="page left">
+              <div className="manga-page layout-p5" data-page="5">
+                <div className="row top">
+                  <KomaPanel pageNum={5} komaNum={1} assetName="p5_koma1" />
+                  <KomaPanel pageNum={5} komaNum={2} assetName="p5_koma2" />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={5} komaNum={3} assetName="p5_koma3" />
+                  <KomaPanel pageNum={5} komaNum={4} assetName="p5_koma4" />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={5} komaNum={5} assetName="p5_koma5" />
+                </div>
+              </div>
+              <div className="nav-area next" onClick={nextSpread} />
             </div>
-            <div className="nav-area prev" onClick={prevSpread} />
+            <div className="page right">
+              <div className="manga-page layout-p4v2" data-page="4">
+                <KomaPanel pageNum={4} komaNum={1} assetName="p4_koma1" className="k1" />
+                <KomaPanel pageNum={4} komaNum={2} assetName="p4_koma2" className="k2" />
+                <KomaPanel pageNum={4} komaNum={3} assetName="p4_koma3" className="k3" />
+                <KomaPanel pageNum={4} komaNum={4} assetName="p4_koma4" className="k4" />
+                <KomaPanel
+                  pageNum={4}
+                  komaNum={5}
+                  assetName="p4_koma5"
+                  className="k5 launcher"
+                />
+              </div>
+              <div className="nav-area prev" onClick={prevSpread} />
+            </div>
+          </div>
+
+          {/* 見開き5：ページ7（左） + ページ6（右） */}
+          <div className={`spread ${currentSpread === 5 ? 'active' : ''}`} data-spread="5">
+            <div className="page left">
+              <div className="manga-page layout-p7b" data-page="7">
+                <div className="row top">
+                  <KomaPanel pageNum={7} komaNum={1} assetName="p7_koma1" className="k1" />
+                  <KomaPanel pageNum={7} komaNum={2} assetName="p7_koma2" className="k2" />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={7} komaNum={3} assetName="p7_koma3" className="k3" />
+                  <KomaPanel pageNum={7} komaNum={4} assetName="p7_koma4" className="k4" />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel
+                    pageNum={7}
+                    komaNum={5}
+                    assetName="p7_koma5"
+                    className="k5 launcher"
+                  />
+                </div>
+              </div>
+              <div
+                className={`nav-area next${
+                  currentSpread === 5 && !progress.hasTetrisScore ? ' tetris-locked' : ''
+                }`}
+                onClick={nextSpread}
+              >
+                {currentSpread === 5 && !progress.hasTetrisScore && (
+                  <div className="tetris-requirement-tooltip">Tetris Over 300 point</div>
+                )}
+              </div>
+            </div>
+            <div className="page right">
+              <div className="manga-page layout-p6" data-page="6">
+                <div className="row top">
+                  <KomaPanel pageNum={6} komaNum={1} assetName="p6_koma1" />
+                  <KomaPanel pageNum={6} komaNum={2} assetName="p6_koma2" />
+                  <KomaPanel pageNum={6} komaNum={3} assetName="p6_koma3" />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={6} komaNum={4} assetName="p6_koma4" className="launcher" />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={6} komaNum={5} assetName="p6_koma5" />
+                  <KomaPanel pageNum={6} komaNum={6} assetName="p6_koma6" />
+                </div>
+              </div>
+              <div className="nav-area prev" onClick={prevSpread} />
+            </div>
+          </div>
+
+          {/* 見開き6：ページ9（左） + ページ8（右） */}
+          <div className={`spread ${currentSpread === 6 ? 'active' : ''}`} data-spread="6">
+            <div className="page left">
+              <div className="manga-page layout-p9" data-page="9">
+                <div className="row top">
+                  <KomaPanel pageNum={9} komaNum={1} assetName="p9_koma1" />
+                  <KomaPanel pageNum={9} komaNum={2} assetName="p9_koma2" />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={9} komaNum={3} assetName="p9_koma3" />
+                  <KomaPanel
+                    pageNum={9}
+                    komaNum={4}
+                    assetName="p9_koma4"
+                    className="launcher"
+                  />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={9} komaNum={5} assetName="p9_koma5" />
+                  <KomaPanel pageNum={9} komaNum={6} assetName="p9_koma6" />
+                </div>
+              </div>
+              <div className="nav-area next" onClick={nextSpread} />
+            </div>
+            <div className="page right">
+              <div className="manga-page layout-p7" data-page="8">
+                <div className="row top">
+                  <KomaPanel pageNum={8} komaNum={1} assetName="p8_koma1" className="left" />
+                  <KomaPanel pageNum={8} komaNum={2} assetName="p8_koma2" className="right" />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={8} komaNum={3} assetName="p8_koma3" />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={8} komaNum={4} assetName="p8_koma4" />
+                  <KomaPanel pageNum={8} komaNum={5} assetName="p8_koma5" />
+                </div>
+              </div>
+              <div className="nav-area prev" onClick={prevSpread} />
+            </div>
+          </div>
+
+          {/* 見開き7：裏表紙 */}
+          <div
+            className={`spread has-empty ${currentSpread === 7 ? 'active' : ''}`}
+            data-spread="7"
+          >
+            <div className="page left empty" />
+            <div className="page right">
+              <div className="cover-container has-image" id="back-cover" data-asset="cover_back">
+                <img
+                  className="cover-image koma-img-el"
+                  alt="cover_back"
+                  data-name="cover_back"
+                  src="/images/cover_back.png"
+                  style={{ display: 'block' }}
+                />
+              </div>
+              <div className="nav-area prev" onClick={prevSpread} />
+            </div>
           </div>
         </div>
       </div>
-      </div>
-      {/* ズーム用オーバーレイ（モーダルの下に敷く） */}
-      <div className={`zoom-overlay${isZoomOverlayActive ? ' active' : ''}`} />
-      {/* ズーム機能 */}
-      <AIBot isActive={isAIBotOpen} onClose={closeActiveUI} />
-      <MiniGameModal
-        isOpen={isMiniGameOpen}
-        onClose={closeActiveUI}
-        gameUrl={currentGameUrl}
-        title={currentGameTitle}
-        fullScreen={isMiniGameFullScreen}
+      <div className={`zoom-overlay${launcher.zoom.isOverlayActive ? ' active' : ''}`} />
+      <AIBot
+        isActive={launcher.active.isAIBotOpen}
+        onClose={launcher.closeActive}
+        onComplete={progress.markAIBotCompleted}
       />
-      {/* Email client now runs as an iframe mini-game, similar to other games */}
+      <MiniGameModal
+        isOpen={launcher.active.isMiniGameOpen}
+        onClose={launcher.closeActive}
+        gameUrl={launcher.active.gameUrl}
+        title={launcher.active.gameTitle}
+        fullScreen={launcher.active.isFullScreen}
+      />
 
-      {/* ページめくり音 ON/OFF トグル */}
       <button
         type="button"
-        className={`sound-toggle${isPageSoundOn ? ' on' : ' off'}`}
-        aria-pressed={isPageSoundOn}
-        aria-label={`ページめくり音 ${isPageSoundOn ? 'オン' : 'オフ'}`}
-        onClick={() => setIsPageSoundOn(!isPageSoundOn)}
+        className={`sound-toggle${sound.isOn ? ' on' : ' off'}`}
+        aria-pressed={sound.isOn}
+        aria-label={`ページめくり音 ${sound.isOn ? 'オン' : 'オフ'}`}
+        onClick={sound.toggle}
       >
-        {isPageSoundOn ? '🔊' : '🔇'}
+        {sound.isOn ? '🔊' : '🔇'}
       </button>
     </>
   );

--- a/InteractiveManga/components/MangaWebtoon.tsx
+++ b/InteractiveManga/components/MangaWebtoon.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import AIBot from './AIBot';
+import MiniGameModal from './MiniGameModal';
+import SharedKomaPanel, { KomaPanelProps } from './KomaPanel';
+import { useGameLauncher } from '@/hooks/useGameLauncher';
+import { useGameProgress } from '@/hooks/useGameProgress';
+
+type KomaProps = Omit<KomaPanelProps, 'hasUfoPrize' | 'isFreshUfoPrize' | 'onLaunch'>;
+
+const LOCK_TOAST_DURATION_MS = 2400;
+const FRESH_PRIZE_DURATION_MS = 2400;
+
+const MangaWebtoon: React.FC = () => {
+  const cameraRef = useRef<HTMLDivElement>(null);
+
+  const progress = useGameProgress();
+  const launcher = useGameLauncher({
+    cameraRef,
+    onUfoPrizeCollected: progress.markPendingUfoPrize,
+    onTetrisScoreAchieved: progress.markTetrisScore,
+  });
+
+  const [lockToastMessage, setLockToastMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const canReveal = !launcher.zoom.isZoomingOut && !launcher.zoom.isZoomed;
+    progress.finalizePendingUfoPrize(canReveal);
+  }, [launcher.zoom.isZoomingOut, launcher.zoom.isZoomed, progress.finalizePendingUfoPrize]);
+
+  useEffect(() => {
+    if (!progress.isFreshUfoPrize) return;
+    const id = window.setTimeout(() => progress.clearFreshUfoPrize(), FRESH_PRIZE_DURATION_MS);
+    return () => window.clearTimeout(id);
+  }, [progress.isFreshUfoPrize, progress.clearFreshUfoPrize]);
+
+  const showLockToast = useCallback((message: string) => {
+    setLockToastMessage(message);
+    window.setTimeout(() => setLockToastMessage(null), LOCK_TOAST_DURATION_MS);
+  }, []);
+
+  const KomaPanel = (props: KomaProps) => (
+    <SharedKomaPanel
+      {...props}
+      hasUfoPrize={progress.hasUfoPrize}
+      isFreshUfoPrize={progress.isFreshUfoPrize}
+      onLaunch={launcher.launchAt}
+      loadingStrategy="lazy"
+    />
+  );
+
+  const aibotLocked = !progress.hasCompletedAIBot;
+  const tetrisLocked = !progress.hasTetrisScore;
+
+  return (
+    <>
+      <div
+        className={`camera-zoom-container webtoon-camera${
+          launcher.zoom.isZoomingIn ? ' zooming-in' : ''
+        }${launcher.zoom.isZoomingOut ? ' zooming-out' : ''}`}
+        ref={cameraRef}
+      >
+        <div className="webtoon-container">
+          <div className="webtoon-cover">
+            <img
+              className="webtoon-cover-image"
+              src="/images/cover_front.png"
+              alt="cover_front"
+              loading="eager"
+              decoding="async"
+            />
+          </div>
+
+          <div className="webtoon-page">
+            <div className="manga-page layout-p1v2" data-page="1">
+              <div className="row top">
+                <KomaPanel pageNum={1} komaNum={1} assetName="p1_koma1" />
+                <KomaPanel pageNum={1} komaNum={2} assetName="p1_koma2" />
+              </div>
+              <div className="row bottom">
+                <KomaPanel pageNum={1} komaNum={3} assetName="p1_koma3" />
+              </div>
+            </div>
+          </div>
+
+          <div className="webtoon-page">
+            <div className="manga-page layout-p2v2" data-page="2">
+              <div className="row top">
+                <KomaPanel
+                  pageNum={2}
+                  komaNum={1}
+                  assetName="p2_koma1"
+                  className="full launcher"
+                />
+              </div>
+              <div className="row mid">
+                <KomaPanel pageNum={2} komaNum={2} assetName="p2_koma2" className="left" />
+                <KomaPanel pageNum={2} komaNum={3} assetName="p2_koma3" className="thin" />
+                <KomaPanel pageNum={2} komaNum={4} assetName="p2_koma4" className="right" />
+              </div>
+              <div className="row bottom">
+                <KomaPanel pageNum={2} komaNum={5} assetName="p2_koma5" />
+                <KomaPanel pageNum={2} komaNum={6} assetName="p2_koma6" />
+              </div>
+            </div>
+          </div>
+
+          <div className="webtoon-page">
+            <div className="manga-page layout-p3v2" data-page="3">
+              <div className="row top">
+                <KomaPanel pageNum={3} komaNum={1} assetName="p3_koma1" className="launcher" />
+              </div>
+              <div className="row bottom">
+                <KomaPanel pageNum={3} komaNum={2} assetName="p3_koma2" />
+              </div>
+            </div>
+          </div>
+
+          <div
+            className={`webtoon-locked-section${aibotLocked ? ' is-locked' : ''}`}
+            onClickCapture={(e) => {
+              if (!aibotLocked) return;
+              e.preventDefault();
+              e.stopPropagation();
+              showLockToast('Talk to your boss first');
+            }}
+          >
+            {aibotLocked && (
+              <div className="webtoon-lock-gate">
+                <div className="webtoon-lock-card">
+                  <div className="webtoon-lock-title">上司との会話を体験しよう</div>
+                  <div className="webtoon-lock-desc">
+                    上の上司のコマをタップして会話を最後まで体験すると、続きが解禁されます。
+                  </div>
+                </div>
+              </div>
+            )}
+
+          <div className="webtoon-page">
+            <div className="manga-page layout-p4v2" data-page="4">
+              <KomaPanel pageNum={4} komaNum={1} assetName="p4_koma1" className="k1" />
+              <KomaPanel pageNum={4} komaNum={2} assetName="p4_koma2" className="k2" />
+              <KomaPanel pageNum={4} komaNum={3} assetName="p4_koma3" className="k3" />
+              <KomaPanel pageNum={4} komaNum={4} assetName="p4_koma4" className="k4" />
+              <KomaPanel pageNum={4} komaNum={5} assetName="p4_koma5" className="k5 launcher" />
+            </div>
+          </div>
+
+          <div className="webtoon-page">
+            <div className="manga-page layout-p5" data-page="5">
+              <div className="row top">
+                <KomaPanel pageNum={5} komaNum={1} assetName="p5_koma1" />
+                <KomaPanel pageNum={5} komaNum={2} assetName="p5_koma2" />
+              </div>
+              <div className="row mid">
+                <KomaPanel pageNum={5} komaNum={3} assetName="p5_koma3" />
+                <KomaPanel pageNum={5} komaNum={4} assetName="p5_koma4" />
+              </div>
+              <div className="row bottom">
+                <KomaPanel pageNum={5} komaNum={5} assetName="p5_koma5" />
+              </div>
+            </div>
+          </div>
+
+          <div className="webtoon-page">
+            <div className="manga-page layout-p6" data-page="6">
+              <div className="row top">
+                <KomaPanel pageNum={6} komaNum={1} assetName="p6_koma1" />
+                <KomaPanel pageNum={6} komaNum={2} assetName="p6_koma2" />
+                <KomaPanel pageNum={6} komaNum={3} assetName="p6_koma3" />
+              </div>
+              <div className="row mid">
+                <KomaPanel pageNum={6} komaNum={4} assetName="p6_koma4" className="launcher" />
+              </div>
+              <div className="row bottom">
+                <KomaPanel pageNum={6} komaNum={5} assetName="p6_koma5" />
+                <KomaPanel pageNum={6} komaNum={6} assetName="p6_koma6" />
+              </div>
+            </div>
+          </div>
+
+          <div className="webtoon-page">
+            <div className="manga-page layout-p7b" data-page="7">
+              <div className="row top">
+                <KomaPanel pageNum={7} komaNum={1} assetName="p7_koma1" className="k1" />
+                <KomaPanel pageNum={7} komaNum={2} assetName="p7_koma2" className="k2" />
+              </div>
+              <div className="row mid">
+                <KomaPanel pageNum={7} komaNum={3} assetName="p7_koma3" className="k3" />
+                <KomaPanel pageNum={7} komaNum={4} assetName="p7_koma4" className="k4" />
+              </div>
+              <div className="row bottom">
+                <KomaPanel pageNum={7} komaNum={5} assetName="p7_koma5" className="k5 launcher" />
+              </div>
+            </div>
+          </div>
+
+          <div
+            className={`webtoon-locked-section${
+              !aibotLocked && tetrisLocked ? ' is-locked' : ''
+            }`}
+            onClickCapture={(e) => {
+              if (aibotLocked || !tetrisLocked) return;
+              e.preventDefault();
+              e.stopPropagation();
+              showLockToast('Tetris Over 300 point');
+            }}
+          >
+            {!aibotLocked && tetrisLocked && (
+              <div className="webtoon-lock-gate">
+                <div className="webtoon-lock-card">
+                  <div className="webtoon-lock-title">テトリスをクリアして続きを読もう</div>
+                  <div className="webtoon-lock-desc">
+                    上のテトリスのコマをタップして、スコア300点以上を達成すると、続きが解禁されます。
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="webtoon-page">
+              <div className="manga-page layout-p7" data-page="8">
+                <div className="row top">
+                  <KomaPanel pageNum={8} komaNum={1} assetName="p8_koma1" className="left" />
+                  <KomaPanel pageNum={8} komaNum={2} assetName="p8_koma2" className="right" />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={8} komaNum={3} assetName="p8_koma3" />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={8} komaNum={4} assetName="p8_koma4" />
+                  <KomaPanel pageNum={8} komaNum={5} assetName="p8_koma5" />
+                </div>
+              </div>
+            </div>
+
+            <div className="webtoon-page">
+              <div className="manga-page layout-p9" data-page="9">
+                <div className="row top">
+                  <KomaPanel pageNum={9} komaNum={1} assetName="p9_koma1" />
+                  <KomaPanel pageNum={9} komaNum={2} assetName="p9_koma2" />
+                </div>
+                <div className="row mid">
+                  <KomaPanel pageNum={9} komaNum={3} assetName="p9_koma3" />
+                  <KomaPanel
+                    pageNum={9}
+                    komaNum={4}
+                    assetName="p9_koma4"
+                    className="launcher"
+                  />
+                </div>
+                <div className="row bottom">
+                  <KomaPanel pageNum={9} komaNum={5} assetName="p9_koma5" />
+                  <KomaPanel pageNum={9} komaNum={6} assetName="p9_koma6" />
+                </div>
+              </div>
+            </div>
+
+            <div className="webtoon-cover">
+              <img
+                className="webtoon-cover-image"
+                src="/images/cover_back.png"
+                alt="cover_back"
+                loading="lazy"
+                decoding="async"
+              />
+            </div>
+          </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={`zoom-overlay${launcher.zoom.isOverlayActive ? ' active' : ''}`} />
+
+      {lockToastMessage && (
+        <div className="webtoon-lock-toast" role="status">
+          {lockToastMessage}
+        </div>
+      )}
+
+      <AIBot
+        isActive={launcher.active.isAIBotOpen}
+        onClose={launcher.closeActive}
+        onComplete={progress.markAIBotCompleted}
+      />
+      <MiniGameModal
+        isOpen={launcher.active.isMiniGameOpen}
+        onClose={launcher.closeActive}
+        gameUrl={launcher.active.gameUrl}
+        title={launcher.active.gameTitle}
+        fullScreen={launcher.active.isFullScreen}
+      />
+    </>
+  );
+};
+
+export default MangaWebtoon;

--- a/InteractiveManga/hooks/useGameLauncher.ts
+++ b/InteractiveManga/hooks/useGameLauncher.ts
@@ -1,0 +1,189 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState, RefObject } from 'react';
+import { LauncherTarget } from '@/lib/gameLaunchers';
+
+const ZOOM_DURATION_MS = 620;
+const ZOOM_CLEANUP_MS = 720;
+const LAUNCH_PULSE_MS = 550;
+
+export interface ActiveGame {
+  isAIBotOpen: boolean;
+  isMiniGameOpen: boolean;
+  gameUrl: string;
+  gameTitle: string;
+  isFullScreen: boolean;
+}
+
+export interface ZoomState {
+  isZoomingIn: boolean;
+  isZoomingOut: boolean;
+  isZoomed: boolean;
+  isOverlayActive: boolean;
+}
+
+interface UseGameLauncherArgs {
+  cameraRef: RefObject<HTMLDivElement | null>;
+  onUfoPrizeCollected: () => void;
+  onTetrisScoreAchieved: () => void;
+}
+
+export interface GameLauncher {
+  active: ActiveGame;
+  zoom: ZoomState;
+  launchAt: (el: HTMLElement, target: LauncherTarget) => void;
+  closeActive: () => void;
+  isBusy: boolean;
+}
+
+const initialActive: ActiveGame = {
+  isAIBotOpen: false,
+  isMiniGameOpen: false,
+  gameUrl: '',
+  gameTitle: '',
+  isFullScreen: false,
+};
+
+const initialZoom: ZoomState = {
+  isZoomingIn: false,
+  isZoomingOut: false,
+  isZoomed: false,
+  isOverlayActive: false,
+};
+
+export const useGameLauncher = ({
+  cameraRef,
+  onUfoPrizeCollected,
+  onTetrisScoreAchieved,
+}: UseGameLauncherArgs): GameLauncher => {
+  const [active, setActive] = useState<ActiveGame>(initialActive);
+  const [zoom, setZoom] = useState<ZoomState>(initialZoom);
+  const cleanupTimerRef = useRef<number | null>(null);
+
+  const isBusy = zoom.isZoomingIn || zoom.isZoomingOut || active.isAIBotOpen || active.isMiniGameOpen;
+
+  const performZoomOut = useCallback(() => {
+    const camera = cameraRef.current;
+    if (camera) {
+      camera.classList.remove('zooming-in');
+      camera.classList.add('zooming-out');
+    }
+    setZoom({
+      isZoomingIn: false,
+      isZoomingOut: true,
+      isZoomed: true,
+      isOverlayActive: false,
+    });
+
+    if (cleanupTimerRef.current) window.clearTimeout(cleanupTimerRef.current);
+    cleanupTimerRef.current = window.setTimeout(() => {
+      if (camera) camera.classList.remove('zooming-out');
+      setZoom(initialZoom);
+      try {
+        document.body.style.overflow = '';
+      } catch (_) {}
+    }, ZOOM_CLEANUP_MS);
+  }, [cameraRef]);
+
+  const closeActive = useCallback(() => {
+    setActive(initialActive);
+    setZoom((prev) =>
+      prev.isZoomed || prev.isZoomingIn ? prev : { ...prev, isOverlayActive: false },
+    );
+
+    if (zoom.isZoomed || zoom.isZoomingIn) {
+      performZoomOut();
+    }
+  }, [zoom.isZoomed, zoom.isZoomingIn, performZoomOut]);
+
+  const launchAt = useCallback(
+    (el: HTMLElement, target: LauncherTarget) => {
+      if (!el || isBusy) return;
+
+      const elRect = el.getBoundingClientRect();
+      const camera = cameraRef.current;
+      if (camera) {
+        const cameraRect = camera.getBoundingClientRect();
+        const cx = elRect.left + elRect.width / 2 - cameraRect.left;
+        const cy = elRect.top + elRect.height / 2 - cameraRect.top;
+        camera.style.setProperty('--zoom-origin-x', `${cx}px`);
+        camera.style.setProperty('--zoom-origin-y', `${cy}px`);
+        camera.classList.add('zooming-in');
+      }
+
+      setZoom({
+        isZoomingIn: true,
+        isZoomingOut: false,
+        isZoomed: false,
+        isOverlayActive: true,
+      });
+      try {
+        document.body.style.overflow = 'hidden';
+      } catch (_) {}
+
+      el.classList.add('launching');
+      window.setTimeout(() => el.classList.remove('launching'), LAUNCH_PULSE_MS);
+
+      if (cleanupTimerRef.current) window.clearTimeout(cleanupTimerRef.current);
+      cleanupTimerRef.current = window.setTimeout(() => {
+        setZoom((prev) => ({ ...prev, isZoomingIn: false, isZoomed: true }));
+        if (target.type === 'aibot') {
+          setActive({
+            isAIBotOpen: true,
+            isMiniGameOpen: false,
+            gameUrl: '',
+            gameTitle: '',
+            isFullScreen: false,
+          });
+        } else {
+          setActive({
+            isAIBotOpen: false,
+            isMiniGameOpen: true,
+            gameUrl: target.url,
+            gameTitle: target.title,
+            isFullScreen: target.fullScreen,
+          });
+        }
+      }, ZOOM_DURATION_MS);
+    },
+    [cameraRef, isBusy],
+  );
+
+  useEffect(() => {
+    const handleMessage = (e: MessageEvent) => {
+      try {
+        if (e.origin !== window.location.origin) return;
+      } catch (_) {}
+      const data = e?.data;
+      if (!data || typeof data !== 'object') return;
+
+      if (data.type === 'CLOSE_MINI_GAME') {
+        closeActive();
+      } else if (data.type === 'UFO_PRIZE_COLLECTED') {
+        const count = typeof data.count === 'number' ? data.count : 0;
+        if (count >= 1) onUfoPrizeCollected();
+      } else if (data.type === 'TETRIS_SCORE_ACHIEVED') {
+        onTetrisScoreAchieved();
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [closeActive, onUfoPrizeCollected, onTetrisScoreAchieved]);
+
+  useEffect(() => {
+    return () => {
+      if (cleanupTimerRef.current) {
+        window.clearTimeout(cleanupTimerRef.current);
+        cleanupTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    active,
+    zoom,
+    launchAt,
+    closeActive,
+    isBusy,
+  };
+};

--- a/InteractiveManga/hooks/useGameProgress.ts
+++ b/InteractiveManga/hooks/useGameProgress.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const UFO_KEY = 'hasUfoPrize';
+const TETRIS_KEY = 'hasTetrisScore';
+const AIBOT_KEY = 'hasCompletedAIBot';
+const FRESH_DURATION_MS = 1800;
+const REVEAL_DELAY_MS = 600;
+
+export interface GameProgress {
+  hasUfoPrize: boolean;
+  hasTetrisScore: boolean;
+  hasCompletedAIBot: boolean;
+  pendingUfoPrize: boolean;
+  isFreshUfoPrize: boolean;
+  markPendingUfoPrize: () => void;
+  markTetrisScore: () => void;
+  markAIBotCompleted: () => void;
+  finalizePendingUfoPrize: (canReveal: boolean) => void;
+  clearFreshUfoPrize: () => void;
+}
+
+export const useGameProgress = (): GameProgress => {
+  const [hasUfoPrize, setHasUfoPrize] = useState(false);
+  const [hasTetrisScore, setHasTetrisScore] = useState(false);
+  const [hasCompletedAIBot, setHasCompletedAIBot] = useState(false);
+  const [pendingUfoPrize, setPendingUfoPrize] = useState(false);
+  const [isFreshUfoPrize, setIsFreshUfoPrize] = useState(false);
+  const revealTimerRef = useRef<number | null>(null);
+  const freshResetTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(UFO_KEY) === 'true') setHasUfoPrize(true);
+      if (localStorage.getItem(TETRIS_KEY) === 'true') setHasTetrisScore(true);
+      if (localStorage.getItem(AIBOT_KEY) === 'true') setHasCompletedAIBot(true);
+    } catch (_) {}
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (revealTimerRef.current) {
+        window.clearTimeout(revealTimerRef.current);
+        revealTimerRef.current = null;
+      }
+      if (freshResetTimerRef.current) {
+        window.clearTimeout(freshResetTimerRef.current);
+        freshResetTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const markPendingUfoPrize = useCallback(() => {
+    setPendingUfoPrize((prev) => prev || true);
+  }, []);
+
+  const markTetrisScore = useCallback(() => {
+    setHasTetrisScore((prev) => {
+      if (prev) return prev;
+      try {
+        localStorage.setItem(TETRIS_KEY, 'true');
+      } catch (_) {}
+      return true;
+    });
+  }, []);
+
+  const markAIBotCompleted = useCallback(() => {
+    setHasCompletedAIBot((prev) => {
+      if (prev) return prev;
+      try {
+        localStorage.setItem(AIBOT_KEY, 'true');
+      } catch (_) {}
+      return true;
+    });
+  }, []);
+
+  const finalizePendingUfoPrize = useCallback(
+    (canReveal: boolean) => {
+      if (!canReveal || !pendingUfoPrize || hasUfoPrize) return;
+      if (revealTimerRef.current) window.clearTimeout(revealTimerRef.current);
+      revealTimerRef.current = window.setTimeout(() => {
+        revealTimerRef.current = null;
+        setIsFreshUfoPrize(true);
+        setHasUfoPrize(true);
+        setPendingUfoPrize(false);
+        try {
+          localStorage.setItem(UFO_KEY, 'true');
+        } catch (_) {}
+
+        if (freshResetTimerRef.current) window.clearTimeout(freshResetTimerRef.current);
+        freshResetTimerRef.current = window.setTimeout(() => {
+          setIsFreshUfoPrize(false);
+          freshResetTimerRef.current = null;
+        }, FRESH_DURATION_MS);
+      }, REVEAL_DELAY_MS);
+    },
+    [pendingUfoPrize, hasUfoPrize],
+  );
+
+  const clearFreshUfoPrize = useCallback(() => {
+    if (freshResetTimerRef.current) {
+      window.clearTimeout(freshResetTimerRef.current);
+      freshResetTimerRef.current = null;
+    }
+    setIsFreshUfoPrize(false);
+  }, []);
+
+  return {
+    hasUfoPrize,
+    hasTetrisScore,
+    hasCompletedAIBot,
+    pendingUfoPrize,
+    isFreshUfoPrize,
+    markPendingUfoPrize,
+    markTetrisScore,
+    markAIBotCompleted,
+    finalizePendingUfoPrize,
+    clearFreshUfoPrize,
+  };
+};

--- a/InteractiveManga/hooks/useIsMobile.ts
+++ b/InteractiveManga/hooks/useIsMobile.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const DEFAULT_BREAKPOINT_PX = 768;
+
+export const useIsMobile = (breakpointPx: number = DEFAULT_BREAKPOINT_PX): boolean | null => {
+  const [isMobile, setIsMobile] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(`(max-width: ${breakpointPx}px)`);
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(e.matches);
+    };
+    handleChange(mediaQuery);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, [breakpointPx]);
+
+  return isMobile;
+};

--- a/InteractiveManga/hooks/usePageTurnSound.ts
+++ b/InteractiveManga/hooks/usePageTurnSound.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const STORAGE_KEY = 'pageSoundOn';
+const SOUND_PATH = '/sounds/ThumbThrough.mp3';
+const VOLUME = 0.25;
+
+export interface PageTurnSound {
+  isOn: boolean;
+  toggle: () => void;
+  play: () => void;
+}
+
+export const usePageTurnSound = (): PageTurnSound => {
+  const [isOn, setIsOn] = useState(true);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    const el = new Audio(SOUND_PATH);
+    try {
+      el.preload = 'auto';
+      el.volume = VOLUME;
+    } catch (_) {}
+    audioRef.current = el;
+    return () => {
+      try {
+        el.pause();
+        el.src = '';
+      } catch (_) {}
+      audioRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved != null) setIsOn(saved === '1');
+    } catch (_) {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, isOn ? '1' : '0');
+    } catch (_) {}
+  }, [isOn]);
+
+  const play = useCallback(() => {
+    if (!isOn) return;
+    const el = audioRef.current;
+    if (!el) return;
+    try {
+      el.currentTime = 0;
+    } catch (_) {}
+    el.play().catch(() => {});
+  }, [isOn]);
+
+  const toggle = useCallback(() => {
+    setIsOn((prev) => !prev);
+  }, []);
+
+  return { isOn, toggle, play };
+};

--- a/InteractiveManga/lib/aiBotDialogue.ts
+++ b/InteractiveManga/lib/aiBotDialogue.ts
@@ -1,0 +1,53 @@
+export type ChoiceId = 'honest' | 'defensive';
+
+export interface ChoiceOption {
+  id: ChoiceId;
+  label: string;
+}
+
+export type DialogueStep =
+  | { kind: 'message'; text: string }
+  | { kind: 'choice'; options: ChoiceOption[] };
+
+export const PRE_CHOICE_STEPS: DialogueStep[] = [
+  { kind: 'message', text: 'お前、この仕事やってて楽しいか？' },
+  {
+    kind: 'message',
+    text: '最近の数字を見たぞ。仮説の切り口は悪くない。──が、熱がない。',
+  },
+  {
+    kind: 'choice',
+    options: [
+      { id: 'honest', label: 'すみません、最近モチベが上がらなくて…' },
+      { id: 'defensive', label: 'いえ、ちゃんとやっています。' },
+    ],
+  },
+];
+
+export const POST_CHOICE_STEPS: Record<ChoiceId, DialogueStep[]> = {
+  honest: [
+    {
+      kind: 'message',
+      text: '正直なのは良い。だが、それは原因じゃない。本音は？',
+    },
+    { kind: 'message', text: 'お前のやりたいことはなんだ？' },
+    {
+      kind: 'message',
+      text: '…答えられないか。まあ、いい。次までに考えておけ。',
+    },
+  ],
+  defensive: [
+    {
+      kind: 'message',
+      text: '数字は嘘をつかない。「やってるつもり」は要らん。',
+    },
+    { kind: 'message', text: 'お前のやりたいことはなんだ？' },
+    {
+      kind: 'message',
+      text: '…答えられないか。まあ、いい。次までに考えておけ。',
+    },
+  ],
+};
+
+export const buildDialogue = (choice: ChoiceId | null): DialogueStep[] =>
+  choice ? [...PRE_CHOICE_STEPS, ...POST_CHOICE_STEPS[choice]] : PRE_CHOICE_STEPS;

--- a/InteractiveManga/lib/gameLaunchers.ts
+++ b/InteractiveManga/lib/gameLaunchers.ts
@@ -1,0 +1,52 @@
+export type LauncherTarget =
+  | { type: 'aibot' }
+  | {
+      type: 'minigame';
+      url: string;
+      title: string;
+      fullScreen: boolean;
+    };
+
+const launcherMap: Record<string, LauncherTarget> = {
+  'p3-1': { type: 'aibot' },
+  'p2-1': {
+    type: 'minigame',
+    url: '/mini-games/p2_koma1_email.html',
+    title: 'Email',
+    fullScreen: true,
+  },
+  'p4-5': {
+    type: 'minigame',
+    url: '/mini-games/p4_koma5_ufo.html',
+    title: 'UFO Catcher',
+    fullScreen: true,
+  },
+  'p6-4': {
+    type: 'minigame',
+    url: '/mini-games/p6_koma4_bubble.html',
+    title: 'Interactive Bubbles',
+    fullScreen: true,
+  },
+  'p7-5': {
+    type: 'minigame',
+    url: '/mini-games/p7_koma5_tetris.html',
+    title: 'Tetris',
+    fullScreen: true,
+  },
+  'p9-4': {
+    type: 'minigame',
+    url: '/mini-games/p9_koma4_shooting.html',
+    title: 'Shooting',
+    fullScreen: true,
+  },
+};
+
+const launcherKey = (pageNum: number, komaNum: number) => `p${pageNum}-${komaNum}`;
+
+export const getLauncherTarget = (
+  pageNum: number,
+  komaNum: number,
+): LauncherTarget | null => launcherMap[launcherKey(pageNum, komaNum)] ?? null;
+
+export const isLauncher = (pageNum: number, komaNum: number): boolean =>
+  launcherKey(pageNum, komaNum) in launcherMap;


### PR DESCRIPTION
- モバイル縦読み版コンポーネント MangaWebtoon を追加（max-width: 768px で自動切替）
- 共通ロジックをフック化（useGameLauncher / useGameProgress / usePageTurnSound / useIsMobile）
- AIBot を Claude API 呼び出しから分岐式ダイアログに置き換え（4〜5メッセージ + 1選択肢）
- AIBot 会話を完了するまで次ページに進めないゲートを追加（PC/モバイル両方）
- UFOキャッチャー未獲得時に隣のコマを「？」プレースホルダで表示してギミックを示唆
- モバイル縦スクロール時のズーム原点座標を camera 要素ローカル座標に修正
- launcher コマをモバイルでは常時グロー
- AIBot 背景画像をモバイル向けに framing 調整